### PR TITLE
fix(docs): update mdc reference url

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ _Italic Text_{#italic_text}
 
 ### For more information
 
-* [MDC Syntax Reference](https://content.nuxtjs.org/guide/writing/mdc/)
+* [MDC Syntax Reference](https://content.nuxt.com/usage/markdown#introduction)
 
 
 <!-- Badges -->


### PR DESCRIPTION
I noticed this url is outdated/broken. 