### PR TITLE
fix(standalone): include inline syntax

### DIFF
--- a/syntaxes/mdc.standalone.tmLanguage.json
+++ b/syntaxes/mdc.standalone.tmLanguage.json
@@ -9,15 +9,15 @@
       "include": "text.html.markdown#frontMatter"
     },
     {
-      "include": "#inline"
-    },
-    {
       "include": "#block"
     }
   ],
   "repository": {
     "block": {
       "patterns": [
+        {
+          "include": "#inline"
+        },
         {
           "include": "#component_block"
         },

--- a/syntaxes/mdc.standalone.tmLanguage.json
+++ b/syntaxes/mdc.standalone.tmLanguage.json
@@ -9,6 +9,9 @@
       "include": "text.html.markdown#frontMatter"
     },
     {
+      "include": "#inline"
+    },
+    {
       "include": "#block"
     }
   ],


### PR DESCRIPTION
Include the `inline` pattern in `mdc.standalone` to enable parsing inline components in shiki.

|Before|After|
|:--:|:--:|
| ![Before](https://github.com/user-attachments/assets/3329c2a3-f3a2-4f2b-9698-7c1321def067) | ![After](https://github.com/user-attachments/assets/eb9889a4-b948-40fb-8dc7-4a7a49ca2d63) |
