### PR TITLE
fix(formatting): make formatting opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,13 @@ Alternatively, to configure per-project, create or edit `.vscode/settings.json` 
 {
   // Required for the extension
   "mdc.enableFormatting": true,
-  // Recommended
-  "editor.tabSize": 2,
-  "editor.insertSpaces": true,
-  "editor.detectIndentation": false,
-  "editor.formatOnPaste": true,
+  // Recommended (for `mdc` and `md`, depending on your usage)
+  "[mdc]": {
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true,
+    "editor.detectIndentation": false,
+    "editor.formatOnPaste": true
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,10 +74,26 @@ The extension enables document code folding for MDC block components (and nested
 
 ### Formatting
 
-The plugin also enables a document format provider. You may customize the settings in your project's `.vscode/settings.json` to override `formatOnType` etc.
+The plugin also enables a document format provider, disabled by default.
+
+To globally configure document formatting in VS Code, search for `mdc.enableFormatting` in Settings.
+
+Alternatively, to configure per-project, create or edit `.vscode/settings.json` in your project's root directory:
+
+```jsonc
+{
+  // Required for the extension
+  "mdc.enableFormatting": true,
+  // Recommended
+  "editor.tabSize": 2,
+  "editor.insertSpaces": true,
+  "editor.detectIndentation": false,
+  "editor.formatOnPaste": true,
+}
+```
 
 > [!Note]
-> Since the format provider utilizes spaces for indention, you may also need to configure your project to insert spaces for tabs within `.mdc` or `.md` files.
+> Since the format provider utilizes spaces for indention, you may also need to configure your project to insert spaces for tabs within `.mdc` or `.md` files as recommended above.
 
 ### For more information
 

--- a/package.json
+++ b/package.json
@@ -68,15 +68,19 @@
         "path": "./snippets/markdown.code-snippets"
       }
     ],
+    "configuration": {
+      "title": "MDC - Markdown Components",
+      "properties": {
+        "mdc.enableFormatting": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable MDC document formatting."
+        }
+      }
+    },
     "configurationDefaults": {
       "[mdc]": {
-        "editor.folding": true,
-        "editor.formatOnSave": true,
-        "editor.formatOnType": true,
-        "editor.formatOnPaste": true,
-        "editor.detectIndentation": false,
-        "editor.insertSpaces": true,
-        "editor.tabSize": 2
+        "editor.folding": true
       }
     }
   },

--- a/syntaxes/mdc.tmLanguage.json
+++ b/syntaxes/mdc.tmLanguage.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "mdc",
-  "displayName": "MDC - Markdown Components",
   "injectionSelector": "L:text.html.markdown",
   "scopeName": "text.markdown.mdc",
   "patterns": [


### PR DESCRIPTION
Fix the document formatting provider to make opt-in via a VS Code setting, disabled by default.