### PR TITLE
fix: show markdown preview menus

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,83 @@
         ]
       }
     ],
+    "menus": {
+      "editor/title": [
+        {
+          "command": "markdown.showPreviewToSide",
+          "when": "editorLangId == mdc && !notebookEditorFocused && !hasCustomMarkdownPreview",
+          "alt": "markdown.showPreview",
+          "group": "navigation"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "markdown.showPreview",
+          "when": "resourceLangId == mdc && !hasCustomMarkdownPreview",
+          "group": "navigation"
+        },
+        {
+          "command": "markdown.findAllFileReferences",
+          "when": "resourceLangId == mdc",
+          "group": "4_search"
+        }
+      ],
+      "editor/title/context": [
+        {
+          "command": "markdown.showPreview",
+          "when": "resourceLangId == mdc && !hasCustomMarkdownPreview",
+          "group": "1_open"
+        },
+        {
+          "command": "markdown.findAllFileReferences",
+          "when": "resourceLangId == mdc"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "markdown.showPreview",
+          "when": "editorLangId == mdc && !notebookEditorFocused",
+          "group": "navigation"
+        },
+        {
+          "command": "markdown.showPreviewToSide",
+          "when": "editorLangId == mdc && !notebookEditorFocused",
+          "group": "navigation"
+        },
+        {
+          "command": "markdown.showLockedPreviewToSide",
+          "when": "editorLangId == mdc && !notebookEditorFocused",
+          "group": "navigation"
+        },
+        {
+          "command": "markdown.showPreviewSecuritySelector",
+          "when": "editorLangId == mdc && !notebookEditorFocused"
+        },
+        {
+          "command": "markdown.preview.refresh",
+          "when": "editorLangId == mdc && !notebookEditorFocused"
+        },
+        {
+          "command": "markdown.findAllFileReferences",
+          "when": "editorLangId == mdc"
+        }
+      ]
+    },
+    "keybindings": [
+      {
+        "command": "markdown.showPreview",
+        "key": "shift+ctrl+v",
+        "mac": "shift+cmd+v",
+        "when": "editorLangId == mdc && !notebookEditorFocused"
+      },
+      {
+        "command": "markdown.showPreviewToSide",
+        "key": "ctrl+k v",
+        "mac": "cmd+k v",
+        "when": "editorLangId == mdc && !notebookEditorFocused"
+      }
+    ],
+
     "snippets": [
       {
         "language": "mdc",


### PR DESCRIPTION
resolves nuxtlabs/vscode-mdc#48

<img width="1327" alt="Screenshot 2025-03-06 at 14 14 46" src="https://github.com/user-attachments/assets/c2c8391b-39b8-4c8b-afa5-9b6d1e5eb07a" />
