### PR TITLE
fix(completions): prop type value

### DIFF
--- a/src/completion-providers.ts
+++ b/src/completion-providers.ts
@@ -651,8 +651,10 @@ export function getMdcComponentPropCompletionItemProvider (componentData: MDCCom
       if (prop.name === 'styles') {
         // Special handling for the `styles` prop since it's always a multiline string
         return `${name}: |\n` + '  ${0:/** Add CSS */}'
-      } else if (type === 'boolean' || type === 'number') {
+      } else if (type === 'boolean') {
         return `${name}: ` + '${0:true}'
+      } else if (type === 'number') {
+        return `${name}: ` + '${0:}'
       } else if (type === 'string') {
         return `${name}: ` + '"${0:}"'
       } else {


### PR DESCRIPTION
When the `prop.type` was a `boolean` or `number` it was always inserting `prop-name: true`

This PR properly resolves the `number` type to just insert the `prop-name: ` ready to accept a number.