### PR TITLE
fix: component metadata ttl

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
         },
         "mdc.componentMetadataCacheTTL": {
           "type": "number",
-          "default": 30,
+          "default": 360,
           "description": "The number of minutes to cache the MDC metadata. Defaults to 30 minutes."
         },
         "mdc.debug": {


### PR DESCRIPTION
The default `30` minute TTL on fetching component data is way too aggressive for remote data (that likely doesn't change that frequently)

Update the default config to 6 hours, and users with local development can always customize if they need a shorter TTL