### PR TITLE
chore: upgrade to pnpm 11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-shamefully-hoist=true
-node-linker=hoisted

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdc",
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@11.2.2",
   "displayName": "Comark - Components in Markdown (previously MDC)",
   "description": "Provides syntax highlighting and colon matching for Comark (Components in Markdown, previously MDC) files.",
   "version": "0.6.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+shamefullyHoist: true
+nodeLinker: hoisted
+minimumReleaseAge: 2880


### PR DESCRIPTION
## Summary
- pin packageManager to pnpm 11.2.2
- move pnpm settings from .npmrc to pnpm-workspace.yaml
- set minimumReleaseAge to 2880 minutes

## Tests
- pnpm install --lockfile-only --frozen-lockfile --ignore-scripts